### PR TITLE
API-CHANGE sapphire folder can now be renamed.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,9 +23,9 @@ ErrorDocument 500 /assets/error-500.html
 
 	RewriteCond %{REQUEST_URI} ^(.*)$
 	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteRule .* sapphire/main.php?url=%1 [QSA]
+	RewriteRule .* framework/main.php?url=%1 [QSA]
 
-	RewriteCond %{REQUEST_URI} ^(.*)/sapphire/main.php$
+	RewriteCond %{REQUEST_URI} ^(.*)/framework/main.php$
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteRule . %1/install.php? [R,L]
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 
 test:
-	$(MAKE) QUERYSTRING="$(QUERYSTRING)" -C sapphire test
+	$(MAKE) QUERYSTRING="$(QUERYSTRING)" -C framework test
 
 getallmodules:
 	if [ -d subsites ]; then svn update subsites; else svn co http://svn.silverstripe.com/open/modules/subsites/trunk subsites; fi

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Base project folder for a SilverStripe ([http://silverstripe.org](http://silverstripe.org)) installation. Requires additional modules to function:
 
- * [`sapphire`](http://github.com/silverstripe/sapphire): Module including the base framework
+ * [`framework`](http://github.com/silverstripe/sapphire): Module including the base framework
  * [`cms`](http://github.com/silverstripe/silverstripe-cms): Module including a Content Management System
  * `themes/blackcandy` (optional)
 
 ## Server Requirements ##
 
-See [doc.silverstripe.org](http://doc.silverstripe.org/sapphire/en/installation/server-requirements)
+See [doc.silverstripe.org](http://doc.silverstripe.org/framework/en/installation/server-requirements)
 
 ## Installation ##
 
-See [installation on different platforms](http://doc.silverstripe.org/sapphire/en/installation/),
-and [installation from source](http://doc.silverstripe.org/sapphire/en/installation/from-source).
+See [installation on different platforms](http://doc.silverstripe.org/framework/en/installation/),
+and [installation from source](http://doc.silverstripe.org/framework/en/installation/from-source).
 
 ## Links ##
 
- * [Changelogs](http://doc.silverstripe.org/sapphire/en/changelogs/)
+ * [Changelogs](http://doc.silverstripe.org/framework/en/changelogs/)
  * [Bugtracker](http://open.silverstripe.org)
  * [Forums](http://silverstripe.org/forums)
  * [Developer Mailinglist](https://groups.google.com/forum/#!forum/silverstripe-dev)

--- a/build.xml
+++ b/build.xml
@@ -233,7 +233,7 @@ Options:
 				<exclude name="tools/**" />
 				<exclude name="**/tests/**" />
 				<exclude name="cms/docs/**" />
-				<exclude name="sapphire/docs/**" />
+				<exclude name="framework/docs/**" />
 				<exclude name="build.xml" />
 				<exclude name="dependent-modules*" />
 				<exclude name="changelog-definitions*" />
@@ -247,7 +247,7 @@ Options:
 		</copy>
 
 		<!-- Write version info to the core folders (shouldn't be in version control) -->
-		<echo msg="${version}" file="${tmp}/${archivename}/sapphire/silverstripe_version" />
+		<echo msg="${version}" file="${tmp}/${archivename}/framework/silverstripe_version" />
 		<echo msg="${version}" file="${tmp}/${archivename}/cms/silverstripe_version" />
 
 		<!-- create tar archive -->

--- a/changelog-definitions.default
+++ b/changelog-definitions.default
@@ -8,5 +8,5 @@
 #
 # <path> <from-commit> <to-commit>
 . 2.4.4-rc1 2.4.5
-sapphire 2.4.4-rc1 2.4.5
+framework 2.4.4-rc1 2.4.5
 cms 2.4.4-rc1 2.4.5

--- a/dependent-modules.default
+++ b/dependent-modules.default
@@ -14,7 +14,7 @@
 #
 # It is recommended to have sqlite3 and cms first with [run_dev_build] set to "false".
 # Having this set to 'false' prevents the execution of the dev/build process, meaning it can be
-# deferred until all dependencies are in place, specifically the sapphire module. List
+# deferred until all dependencies are in place, specifically the framework module. List
 # all additional modules after that. 
 #
 # Examples
@@ -24,7 +24,7 @@
 
 
 cms:master:2.4.5 git://github.com/silverstripe/silverstripe-cms.git
-sapphire:master:2.4.5 git://github.com/silverstripe/sapphire.git
+framework:master:2.4.5 git://github.com/silverstripe/sapphire.git
 
 
 

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@
  ************************************************************************************/
 
 /**
- * This script bolts on top of SilverStripe/Sapphire to allow access without the use of .htaccess
+ * This script bolts on top of SilverStripe to allow access without the use of .htaccess
  * rewriting rules.
  */
 
@@ -60,4 +60,4 @@ if($url && file_exists($fileName)) {
 	die();
 }
 
-require_once('sapphire/main.php');
+require_once('framework/main.php');

--- a/install-frameworkmissing.html
+++ b/install-frameworkmissing.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
-		<title>The sapphire module is missing</title>
-		<link rel="stylesheet" type="text/css" href="sapphire/dev/install/css/install.css" />
+		<title>The SilverStripe Framework is missing</title>
+		<link rel="stylesheet" type="text/css" href="framework/dev/install/css/install.css" />
 	</head>
 	<body>
 		<div id="BgContainer">
@@ -15,12 +15,12 @@
 				
 				<div id="Layout">
 					<div class="typography">
-						<p><strong>The sapphire module is missing</strong> - To run the installer, at least the 'sapphire' module and the 'simple' theme are required</p>
+						<p><strong>The SilverStripe Framework is missing</strong> - To run the installer, at least the 'framework' module and the 'simple' theme are required</p>
 		
 						<p>If you downloaded a pre-packaged zip or tar.gz, something might have gone wrong with the packaging
 						process. Please try re-downloading, or try an older version</p>
 
-						<p>If you downloaded this from github, you need to install the 'sapphire' and 'simple' theme code bases
+						<p>If you downloaded this from github, you need to install the 'framework' and 'simple' theme code bases
 						in subdirectories of this directory. You can do this manually, or by running the tools/new-project
 						script from the command line</p>
 					</div>

--- a/install.php
+++ b/install.php
@@ -9,5 +9,5 @@
  ************************************************************************************
  ************************************************************************************/
 
-if (!file_exists('sapphire') || !file_exists('sapphire/_config.php')) include "install-sapphiremissing.html";
-else include('./sapphire/dev/install/install.php');
+if (!file_exists('framework') || !file_exists('framework/_config.php')) include "install-frameworkmissing.html";
+else include('./framework/dev/install/install.php');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,19 @@
 <!-- 
 	Usage: 
 	 - "phpunit": Runs all tests in all folders
-	 - "phpunit sapphire/tests/": Run all tests of the sapphire module
-	 - "phpunit sapphire/tests/filesystem": Run all filesystem tests within the sapphire module
-	 - "phpunit sapphire/tests/filesystem/FolderTest.php": Run a single test
+	 - "phpunit framework/tests/": Run all tests of the framework module
+	 - "phpunit framework/tests/filesystem": Run all filesystem tests within the framework module
+	 - "phpunit framework/tests/filesystem/FolderTest.php": Run a single test
 	 - "phpunit <dash><dash>coverage-html assets/": Generate coverage report (replace <dash> with "-", requires xdebug)
 	
 	Further information:
 	- http://www.phpunit.de/manual/current/en/textui.html for more commandline options.
 	- http://github.com/chillu/silverstripe-doc-restructuring/blob/master/master/cms/docs/en/howto/phpunit-configuration.md
 	  for more information on configuration and execution options.
-	- sapphire/dev/TestRunner.php for an alternative way to run unit tests through the "sake" CLI tool.
+	- framework/dev/TestRunner.php for an alternative way to run unit tests through the "sake" CLI tool.
 -->
 <phpunit 
-	bootstrap="sapphire/tests/bootstrap.php"
+	bootstrap="framework/tests/bootstrap.php"
 	colors="true"
 >
 	<testsuite name="Default">
@@ -22,15 +22,15 @@
 	
 	<filter>
 		<blacklist>
-			<directory suffix=".php">sapphire/dev/</directory>
-			<directory suffix=".php">sapphire/thirdparty/</directory>
+			<directory suffix=".php">framework/dev/</directory>
+			<directory suffix=".php">framework/thirdparty/</directory>
 			<directory suffix=".php">cms/thirdparty/</directory>
-			<file>sapphire/tests/PhpSyntaxTest.php</file>
+			<file>framework/tests/PhpSyntaxTest.php</file>
 		</blacklist>
 	</filter>
 	
 	<listeners>
-		<listener class="SS_TestListener" file="sapphire/dev/TestListener.php">
+		<listener class="SS_TestListener" file="framework/dev/TestListener.php">
 		</listener>
 	</listeners>
 	

--- a/rewritetest.php
+++ b/rewritetest.php
@@ -83,7 +83,7 @@ RewriteBase $base
 
 RewriteCond %{REQUEST_URI} ^(.*)$
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule .* sapphire/main.php?url=%1&%{QUERY_STRING} [L]
+RewriteRule .* framework/main.php?url=%1&%{QUERY_STRING} [L]
 TEXT
 	;
 	
@@ -114,7 +114,7 @@ RewriteBase $base
 
 RewriteCond %{REQUEST_URI} ^(.*)$
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule .* $_SERVER[DOCUMENT_ROOT]/sapphire/main.php?url=%1&%{QUERY_STRING} [L]
+RewriteRule .* $_SERVER[DOCUMENT_ROOT]/framework/main.php?url=%1&%{QUERY_STRING} [L]
 TEXT
 	;
 	

--- a/tools/CreateChangelog.php
+++ b/tools/CreateChangelog.php
@@ -27,7 +27,7 @@ class CreateChangelog extends SilverStripeBuildTask {
 	
 	public $commitUrls = array(
 		'.' => 'https://github.com/silverstripe/silverstripe-installer/commit/%s',
-		'sapphire' => 'https://github.com/silverstripe/sapphire/commit/%s',
+		'framework' => 'https://github.com/silverstripe/sapphire/commit/%s',
 		'cms' => 'https://github.com/silverstripe/silverstripe-cms/commit/%s',
 		'themes/blackcandy' => 'https://github.com/silverstripe-themes/silverstripe-blackcandy/commit/%s',
 	);
@@ -204,9 +204,9 @@ class CreateChangelog extends SilverStripeBuildTask {
 			if (count($bits) == 1) {
 				$repos[$bits[0]] = "";
 			} elseif (count($bits) == 2) {
-				$repos[$bits[0]] = array($bits[1], null);    //sapphire => array(from => HEAD)
+				$repos[$bits[0]] = array($bits[1], null);    //framework => array(from => HEAD)
 			} elseif (count($bits) == 3) {
-				$repos[$bits[0]] = array($bits[1],$bits[2]);    //sapphire => array(from => to)
+				$repos[$bits[0]] = array($bits[1],$bits[2]);    //framework => array(from => to)
 			} else {
 				continue;
 			}

--- a/tools/SilverStripeBuildTask.php
+++ b/tools/SilverStripeBuildTask.php
@@ -40,9 +40,9 @@ TEXT;
 	}
 
 	function devBuild() {
-		if (file_exists('sapphire/cli-script.php')) {
+		if (file_exists('framework/cli-script.php')) {
 			$this->log("Running dev/build");
-			$this->exec('php sapphire/cli-script.php dev/build');
+			$this->exec('php framework/cli-script.php dev/build');
 		}
 	}
 	

--- a/tools/lib/template.php
+++ b/tools/lib/template.php
@@ -6,20 +6,20 @@ Structure is likely to change at some point
 */
 
 $template = array(
-	'sapphire' => new Github(array(
+	'framework' => new Github(array(
 		'user' => 'silverstripe', 
 		'project' => 'sapphire', 
-		'branch' => SAPPHIRE_CURRENT_BRANCH
+		'branch' => FRAMEWORK_CURRENT_BRANCH
 	)),
 	'cms' => new Github(array(
 		'user' => 'silverstripe', 
 		'project' => 'silverstripe-cms',
-		'branch' => SAPPHIRE_CURRENT_BRANCH
+		'branch' => FRAMEWORK_CURRENT_BRANCH
 	)),
 	'themes/simple' => new GithubSparse(array(
 		'user' => 'silverstripe-themes', 
 		'project' => 'silverstripe-simple',
-		'branch' => SAPPHIRE_CURRENT_BRANCH,
+		'branch' => FRAMEWORK_CURRENT_BRANCH,
 		'subdir' => ''
 	))
 );

--- a/tools/versions.php
+++ b/tools/versions.php
@@ -1,3 +1,4 @@
 <?php
 
-define('SAPPHIRE_CURRENT_BRANCH', 'master');
+define('FRAMEWORK_CURRENT_BRANCH', 'master');
+define('SAPPHIRE_CURRENT_BRANCH', FRAMEWORK_CURRENT_BRANCH);


### PR DESCRIPTION
Installer part of https://github.com/silverstripe/sapphire/pull/309

I like .mergesources.yml alone as it's still using SVN paths, so I don't think it's being used any more.
