### PR TITLE
BUGFIX: Tutorial theme doctype

### DIFF
--- a/themes/tutorial/templates/Page.ss
+++ b/themes/tutorial/templates/Page.ss
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
+<!doctype html>
+<html>
 	<head>
 		<% base_tag %>
 		<link rel="stylesheet" type="text/css" href="tutorial/css/layout.css" />


### PR DESCRIPTION
Update doctype to use html5 rather than xHTML. Prevents unformed XML
error
