### PR TITLE
Remove compass dependency, too slow even for development at the moment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 		"silverstripe-themes/simple": "*"
 	},
 	"require-dev": {
-		"silverstripe/compass": "*",
 		"silverstripe/docsviewer": "*",
 		"phpunit/phpunit": "3.7.*"
 	},


### PR DESCRIPTION
Use compass on CLI instead, or re-add the module manually
via "composer require".

See https://github.com/silverstripe-labs/silverstripe-compass/issues/9
