### PR TITLE
Ignore build-related files in "git archive" (fixes #8167)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+.gitattributes export-ignore
+behat.yml export-ignore
+build.properties.default export-ignore
+build.xml export-ignore
+changelog-definitions.default export-ignore
+CONTRIBUTING.md export-ignore
+dependent-modules.default export-ignore
+Makefile export-ignore
+phpunit.teamcity.mssql.xml export-ignore
+phpunit.teamcity.postgresql.xml export-ignore
+phpunit.teamcity.sqlite3.xml export-ignore
+phpunit.teamcity.xml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
See http://open.silverstripe.org/ticket/8167

This is useful for keeping standard "composer create-project"
checkouts clean. Unless they use "--keep-vcs", in which case
.gitattributes is (correctly) ignored. 

This has the side effect that archive-checkouts can't
run phing or phpunit scripts, but I think that's
acceptable.

Will also affect the github.com downloads by the way.
