### PR TITLE
IIS 7.5 does not like forward slash at the end of silverstripe-cache

### DIFF
--- a/web.config
+++ b/web.config
@@ -3,7 +3,7 @@
 		<security>
 			<requestFiltering>
 				<hiddenSegments>
-					<add segment="silverstripe-cache/" />
+					<add segment="silverstripe-cache" />
 					<add segment="vendor" />
 					<add segment="composer.json" />
 					<add segment="composer.lock" />


### PR DESCRIPTION
IIS 7.5 does not like forward slash at the end of silverstripe-cache
