### PR TITLE
Remove require-dev section, composer doesn't handle it well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,6 @@
 		"silverstripe/framework": "3.0.*@stable",
 		"silverstripe-themes/simple": "*"
 	},
-	"require-dev": {
-		"silverstripe/docsviewer": "*",
-		"silverstripe/behat-extension": "*",
-		"silverstripe/buildtools": "*",
-		"phpunit/phpunit": "3.7.*"
-	},
 	"config": {
 		"process-timeout": 600	
 	},


### PR DESCRIPTION
/cc @sminnee @hafriedlander 

Any "composer require <module>" call will first call
a "composer update". This _automatically_ includes dev requirements,
without providing a way to turn off this behaviour.
A workaround would be "composer require --no-update <module> && composer update --no-dev <module>",
but that drastically reduces the usefulness of the command
for our target audience (moderately technical devs).

I actually think this is a bug in composer, and it should at least
allow "composer require --no-dev <module>", but until that gets implemented
I think its best to remove the dev dependencies altogether.

In the end, the small faction of devs needing the dev dependencies
also know how to install them on their own. And having a local phpunit
build actually gets in the way more than it helps in case you have
it installed through PEAR already (can get really weird when using the
PEAR provided "phpunit" binary, but the autoloader finds the composer managed classes).

I've opened an issue with composer to remedy this: https://github.com/composer/composer/issues/1874
