### PR TITLE
FIX: Put self.version in composer dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"description": "The SilverStripe Framework Installer",
 	"require": {
 		"php": ">=5.3.2",
-		"silverstripe/cms": "3.1.x-dev",
-		"silverstripe/framework": "3.1.x-dev",
+		"silverstripe/cms": "self.version",
+		"silverstripe/framework": "self.version",
 		"silverstripe-themes/simple": "*"
 	},
 	"config": {


### PR DESCRIPTION
Now that https://github.com/composer/composer/pull/1883 is in Composer, self.version
will work as a requirement for framework & cms.  This will simplify the release
process a great deal.

Ultimately, the release of rc1 will be the place to test that, but it seems appropriate
to get this in there for that.

If it succeeds with 3.1-rc1, I'd suggest we backport to 3.0 and 2.4.
