### PR TITLE
NEW: Added post-install and post-update dev/build call.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,9 @@
 	"config": {
 		"process-timeout": 600	
 	},
+	"scripts": {
+		"post-install-cmd": "php ./framework/cli-script.php dev/build",
+		"post-update-cmd": "php ./framework/cli-script.php dev/build"
+	},
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
With this change, composer will automatically call dev/build after an update or install
command.  The main reason that this is 3.1-only is that previous releases would have
necessitated the use of 'sudo -u www-data', which is too environment-specific.

One thing that this may cause problems with is 'composer create-project' in an environment
without a _ss_environment file.  It will call dev/build, and dev/build will throw an
error.  That should be fixed in a subsequent commit.
