### PR TITLE
Fixing regression in composer post scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,5 @@
 	"config": {
 		"process-timeout": 600	
 	},
-	"scripts": {
-		"post-install-cmd": "php ./framework/cli-script.php dev/build",
-		"post-update-cmd": "php ./framework/cli-script.php dev/build"
-	},
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
Fixes regression on Windows where composer update and composer install because the path is hardcoded to only work on *nix systems.

Reference on the forum: http://www.silverstripe.org/installing-silverstripe/show/24499
