### PR TITLE
Removed misleading comments and legacy requirement calls

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -30,14 +30,8 @@ class Page_Controller extends ContentController {
 
 	public function init() {
 		parent::init();
-
-		// Note: you should use SS template require tags inside your templates 
-		// instead of putting Requirements calls here.  However these are 
-		// included so that our older themes still work
-		Requirements::themedCSS('reset');
-		Requirements::themedCSS('layout'); 
-		Requirements::themedCSS('typography'); 
-		Requirements::themedCSS('form'); 
+		// You can include any CSS or JS required by your project here.
+		// See: http://doc.silverstripe.org/framework/en/reference/requirements
 	}
 
 }


### PR DESCRIPTION
The instructions in the init() function seem to be at odds with the current documentation which suggests that it is preferable to include requirements in PHP code rather than in templates.

Also the requirement calls here are supposedly included so that older themes still work - but how old are we talking? I would assume that these older themes would not be compatible with SS3.1, and the bundled Simple theme does not need these requirement calls in the init() function, making them redundant.

I am guessing that the Installer is primarily used by people just getting started with SilverStripe, so ideally this bundled example Page.php should provide a clear pathway to best practice SS development, rather than supporting out-dated code.
