### PR TITLE
Correct YAML syntax

### DIFF
--- a/mysite/_config/config.yml
+++ b/mysite/_config/config.yml
@@ -1,6 +1,8 @@
 ---
 Name: mysite
-After: 'framework/*','cms/*'
+After:
+  - 'framework/*'
+  - 'cms/*'
 ---
 # YAML configuration for SilverStripe
 # See http://doc.silverstripe.org/framework/en/topics/configuration


### PR DESCRIPTION
This aligns the config file with the documentation and prevents errors in YAML validators.
