### PR TITLE
Don't block rewriting .php URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -30,7 +30,6 @@ ErrorDocument 500 /assets/error-500.html
 
 	RewriteCond %{REQUEST_URI} ^(.*)$
 	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteCond %{REQUEST_URI} !\.php$
 	RewriteRule .* framework/main.php?url=%1 [QSA]
 
 	RewriteCond %{REQUEST_URI} ^(.*)/framework/main.php$


### PR DESCRIPTION
Why this was ever added is beyond me. There's no reason why this specific extension should be singled out, especially given the `!-f` rule above it.
