### PR TITLE
Require php-tidy for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 		"silverstripe-themes/simple": "*"
 	},
 	"require-dev": {
+		"ext-tidy": "*",
 		"phpunit/PHPUnit": "~3.7@stable"
 	},
 	"config": {


### PR DESCRIPTION
php-tidy is required to run the test suite.