### PR TITLE
Deny README.md from being web accessible

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,6 +13,12 @@
 	Deny from all
 </Files>
 
+# Deny access to README.md
+<Files README.md>
+	Order deny,allow
+	Deny from all
+</Files>
+
 # Deny access to YAML configuration files which might include sensitive information
 <Files ~ "\.ya?ml$">
 	Order allow,deny


### PR DESCRIPTION
By default this gives away README.md.

This would stop that - although I assume modules would need the same rule in their .htaccess