### PR TITLE
Prefer stable packages while still allowing dev ones. Fixes #100

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,14 @@
 		"silverstripe/framework": "self.version",
 		"silverstripe/reports": "self.version",
 		"silverstripe/siteconfig": "self.version",
-		"silverstripe-themes/simple": "*"
+		"silverstripe-themes/simple": "3.1.*"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7@stable"
+		"phpunit/PHPUnit": "~3.7"
 	},
 	"config": {
 		"process-timeout": 600
 	},
+	"prefer-stable": true,
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
Although the original ticket recommended increasing our
minimum-stability, this change gives us the best of both worlds.

 - Where stable packages are available and meet the requirements, they
   will be used.
 - Where stable packages aren’t available or they don’t meet the
   dependency requirements, non-stable packages are still allowed.

As part of this I have also tightened up the silverstripe-themes req
version, as `*` is an anti-pattern. The versioning of the theme has
rightly split off from the versioning of the framework; it looks like
3.1.* is what we should expect.

Arguably, we could set the dependency to ~3.1, but in this case I think
it’s fine to be conservative.