### PR TITLE
FIX: install.php5 overwrite of existing .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,3 @@
-### SILVERSTRIPE START ###
-
 # Deny access to templates (but allow from localhost)
 <Files *.ss>
 	Order deny,allow
@@ -60,4 +58,3 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteRule . %1/install.php? [R,L]
 
 </IfModule>
-### SILVERSTRIPE END ###


### PR DESCRIPTION
Original issue: silverstripe/silverstripe-installer#58

Partial fix: silverstripe/silverstripe-installer#103 and silverstripe/silverstripe-framework#4602

However, presence of the "### SILVERSTRIPE START ###" and "### SILVERSTRIPE END ###" strings in existing .htaccess results in an incorrect overwriting of .htaccess during installation ( see lines https://github.com/silverstripe/silverstripe-framework/blob/3/dev/install/install.php5#L1567-L1578 ) which deletes the partial fix silverstripe/silverstripe-installer#103.