### PR TITLE
ENH prevent redirect loop

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -39,6 +39,10 @@ ErrorDocument 500 /assets/error-500.html
 
 	SetEnv HTTP_MOD_REWRITE On
 	RewriteEngine On
+	
+	## Internal Redirect Loop Protection
+	RewriteCond %{ENV:REDIRECT_STATUS} 200
+	RewriteRule ^ - [L]
 
 	# Enable HTTP Basic authentication workaround for PHP running in CGI mode
 	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]


### PR DESCRIPTION
To reproduce, rename your framework directory to framework2 (to simulate a missing framework) and make a http request.

Before change, the reponse is 500 Internal Server Error, and the error is (apache/error.log):
"AH00124: Request exceeded the limit of 10 internal redirects due to probable configuration error. ..."

After change, the response is 404 Not Found, and contains helpful error message: 
"The requested URL /framework/main.php was not found on this server"

Note: I'm not sure exactly where this code should go, if it's the first rule or after http basic auth etc.