### PR TITLE
Additions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ _ss_environment.php
 
 # ignore composer vendor folder
 /vendor/
+
+# create a global .gitignore to control your environment excludes
+# git config --global core.excludesfile ~/.gitignore_global

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,12 @@ _ss_environment.php
 # ignore composer vendor folder
 /vendor/
 
+# ignore SS modules
+/framework/
+/cms/
+/reports/
+/siteconfig/
+/themes/
+
 # create a global .gitignore to control your environment excludes
 # git config --global core.excludesfile ~/.gitignore_global


### PR DESCRIPTION
I propose 2 additions to .gitignore

1. add SilverStripe modules (they are external like /vendor/)
2. add a note how to create global gitignore file. It specifies that environment excludes should not be a part of this file and gives a hint how to handle them.