### PR TITLE
Revert "Require php-tidy for dev dependencies (#87)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 		"silverstripe-themes/simple": "*"
 	},
 	"require-dev": {
-		"ext-tidy": "*",
 		"phpunit/PHPUnit": "~3.7@stable"
 	},
 	"config": {


### PR DESCRIPTION
This reverts commit bb24a9192eef39070b010520003f6ff10c6521f0.

Fixes https://github.com/silverstripe/silverstripe-installer/issues/120