### PR TITLE
API Enable friendly error HTTP code by default for new projects

### DIFF
--- a/mysite/_config/config.yml
+++ b/mysite/_config/config.yml
@@ -9,3 +9,5 @@ After:
 # Caution: Indentation through two spaces, not tabs
 SSViewer:
   theme: 'simple'
+Debug:
+  friendly_error_httpcode: true


### PR DESCRIPTION
Enable https://github.com/silverstripe/silverstripe-framework/pull/5556 by default for new projects