### PR TITLE
.gitignore everything installed by composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,10 @@ _ss_environment.php
 # ignore build tools
 /tools/phing-metadata
 
-# ignore composer vendor folder
+# ignore folders maintained by composer
+/asset-admin/
+/cms/
+/framework/
+/reports/
+/siteconfig/
 /vendor/


### PR DESCRIPTION
When saving to a git repository, everything installed by composer should be ignored, including SilverStripe framework and all default modules. 

This change adds all folders that are created through the default composer.json in this installer package.