### PR TITLE
Support composer update out-of-the-box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
 	"description": "The SilverStripe Framework Installer",
 	"require": {
 		"php": ">=5.3.3",
-		"silverstripe/cms": "self.version",
-		"silverstripe/framework": "self.version",
-		"silverstripe/reports": "self.version",
-		"silverstripe/siteconfig": "self.version",
-		"silverstripe-themes/simple": "3.1.*"
+		"silverstripe/cms": "^3.4",
+		"silverstripe/framework": "^3.4",
+		"silverstripe/reports": "^3.4",
+		"silverstripe/siteconfig": "^3.4",
+		"silverstripe-themes/simple": "^3"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"


### PR DESCRIPTION
Is it not a better default to support `composer update` out of the box? Without the ^ symbols, it always just downloads the same version. 

Thanks to semantic versioning, `^self.version` will make composer update to the most recent version without breaking changes.