### PR TITLE
FIX use latest dev-master for asset-admin composer contraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"silverstripe/reports": "self.version",
 		"silverstripe/siteconfig": "self.version",
 		"silverstripe-themes/simple": "3.1.*",
-		"silverstripe/asset-admin": "^1"
+		"silverstripe/asset-admin": "1.0.x-dev"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~4.8"


### PR DESCRIPTION
* Resolves #131 

Unless there's a reason for keeping `^1`! :)