### PR TITLE
Remove i18n::set_locale from default installer

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -7,6 +7,3 @@ global $database;
 $database = '';
 
 require_once('conf/ConfigureFromEnv.php');
-
-// Set the site locale
-i18n::set_locale('en_US');


### PR DESCRIPTION
It's not necessary; i18n default_locale is already `en_US` and we want to make this file redundant anyway at some point.