### PR TITLE
BUG Fix incorrect backslash escaping in htaccess template

### DIFF
--- a/assets/.htaccess
+++ b/assets/.htaccess
@@ -14,10 +14,10 @@
 
     # Allow error pages
     RewriteCond %{REQUEST_FILENAME} -f
-    RewriteRule error[^\/]*.html$ - [L]
+    RewriteRule error[^\\/]*\.html$ - [L]
 
     # Block invalid file extensions
-    RewriteCond %{REQUEST_URI} !.(?i:ace|arc|arj|asf|au|avi|bmp|bz2|cab|cda|css|csv|dmg|doc|docx|dotx|dotm|flv|gif|gpx|gz|hqx|ico|jar|jpeg|jpg|js|kml|m4a|m4v|mid|midi|mkv|mov|mp3|mp4|mpa|mpeg|mpg|ogg|ogv|pages|pcx|pdf|png|pps|ppt|pptx|potx|potm|ra|ram|rm|rtf|sit|sitx|tar|tgz|tif|tiff|txt|wav|webm|wma|wmv|xls|xlsx|xltx|xltm|zip|zipx)$
+    RewriteCond %{REQUEST_URI} !\.(?i:ace|arc|arj|asf|au|avi|bmp|bz2|cab|cda|css|csv|dmg|doc|docx|dotx|dotm|flv|gif|gpx|gz|hqx|ico|jar|jpeg|jpg|js|kml|m4a|m4v|mid|midi|mkv|mov|mp3|mp4|mpa|mpeg|mpg|ogg|ogv|pages|pcx|pdf|png|pps|ppt|pptx|potx|potm|ra|ram|rm|rtf|sit|sitx|tar|tgz|tif|tiff|txt|wav|webm|wma|wmv|xls|xlsx|xltx|xltm|zip|zipx)$
     RewriteRule .* - [F]
 
     # Non existant files passed to requesthandler


### PR DESCRIPTION
Need to escape these slashes since they were resulting in unescaped `.` in the htaccess regex.

Merge with https://github.com/silverstripe/silverstripe-framework/pull/6061