### PR TITLE
Added GraphQL dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"silverstripe/reports": "4.0.x-dev",
 		"silverstripe/siteconfig": "4.0.x-dev",
 		"silverstripe-themes/simple": "~3.2.0",
-		"silverstripe/asset-admin": "1.0.x-dev"
+		"silverstripe/asset-admin": "1.0.x-dev",
+		"silverstripe/graphql": "0.2.x-dev"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~4.8"


### PR DESCRIPTION
This is required here in order for the "cow" release tool
to include the module in tagging releases.

At the moment, it's only an indirect asset-admin dependency,
but will become a framework dependency once we switch
CampaignAdmin to use GraphQL as well.

Merge after https://github.com/silverstripe/silverstripe-asset-admin/pull/368