### PR TITLE
Block common log file names in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -49,6 +49,7 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteRule ^vendor(/|$) - [F,L,NC]
 	RewriteRule silverstripe-cache(/|$) - [F,L,NC]
 	RewriteRule composer\.(json|lock) - [F,L,NC]
+	RewriteRule (error|silverstripe|debug)\.log - [F,L,NC]
 
 	# Process through SilverStripe if no file with the requested name exists.
 	# Pass through the original path as a query parameter, and retain the existing parameters.


### PR DESCRIPTION
I've seen it happen quiet frequently that error logs are located in the web root or `Debug::log()` statements where forgotten and deployed to live.
I think disallowing the most common file names here would limit the potential of accidentally exposing sensitive information drastically (especially because the `Debug::log()` file name or location can not be configured).