### PR TITLE
Add PHPCS standard for SS 3.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = tab
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
  */
 
 // This is the URL of the script that everything must be viewed with.
-define('BASE_SCRIPT_URL','index.php/');
+define('BASE_SCRIPT_URL', 'index.php/');
 
 $ruLen = strlen($_SERVER['REQUEST_URI']);
 $snLen = strlen($_SERVER['SCRIPT_NAME']);
@@ -23,26 +23,28 @@ $snLen = strlen($_SERVER['SCRIPT_NAME']);
 $isIIS = (strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false);
 
 // IIS will populate server variables using one of these two ways
-if($isIIS) {
-	if($_SERVER['REQUEST_URI'] == $_SERVER['SCRIPT_NAME']) {
-		$url = "";
-	} else if($ruLen > $snLen && substr($_SERVER['REQUEST_URI'],0,$snLen+1) == ($_SERVER['SCRIPT_NAME'] . '/')) {
-		$url = substr($_SERVER['REQUEST_URI'],$snLen+1);
-		$url = strtok($url, '?');
-	} else {
-		$url = $_SERVER['REQUEST_URI'];
-		if($url[0] == '/') $url = substr($url,1);
-		$url = strtok($url, '?');
-	}
+if ($isIIS) {
+    if ($_SERVER['REQUEST_URI'] == $_SERVER['SCRIPT_NAME']) {
+        $url = "";
+    } elseif ($ruLen > $snLen && substr($_SERVER['REQUEST_URI'], 0, $snLen + 1) == ($_SERVER['SCRIPT_NAME'] . '/')) {
+        $url = substr($_SERVER['REQUEST_URI'], $snLen+1);
+        $url = strtok($url, '?');
+    } else {
+        $url = $_SERVER['REQUEST_URI'];
+        if ($url[0] == '/') {
+            $url = substr($url, 1);
+        }
+        $url = strtok($url, '?');
+    }
 
 // Apache will populate the server variables this way
 } else {
-	if($ruLen > $snLen && substr($_SERVER['REQUEST_URI'],0,$snLen+1) == ($_SERVER['SCRIPT_NAME'] . '/')) {
-		$url = substr($_SERVER['REQUEST_URI'],$snLen+1);
-		$url = strtok($url, '?');
-	} else {
-		$url = "";
-	}
+    if ($ruLen > $snLen && substr($_SERVER['REQUEST_URI'], 0, $snLen+1) == ($_SERVER['SCRIPT_NAME'] . '/')) {
+        $url = substr($_SERVER['REQUEST_URI'], $snLen+1);
+        $url = strtok($url, '?');
+    } else {
+        $url = "";
+    }
 }
 
 $_GET['url'] = $_REQUEST['url'] = $url;
@@ -53,14 +55,14 @@ $fileName = dirname($_SERVER['SCRIPT_FILENAME']) . '/' . $url;
  * This code is a very simple wrapper for sending files
  * Very quickly pass through references to files
  */
-if($url && file_exists($fileName)) {
-	$fileURL = (dirname($_SERVER['SCRIPT_NAME'])=='/'?'':dirname($_SERVER['SCRIPT_NAME'])) . '/' . $url;
-	if(isset($_SERVER['QUERY_STRING'])) {
-		$fileURL .= '?' . $_SERVER['QUERY_STRING'];
-	}
-	header($_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently');
-	header("Location: $fileURL");
-	die();
+if ($url && file_exists($fileName)) {
+    $fileURL = (dirname($_SERVER['SCRIPT_NAME'])=='/'?'':dirname($_SERVER['SCRIPT_NAME'])) . '/' . $url;
+    if (isset($_SERVER['QUERY_STRING'])) {
+        $fileURL .= '?' . $_SERVER['QUERY_STRING'];
+    }
+    header($_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently');
+    header("Location: $fileURL");
+    die();
 }
 
-require_once('framework/main.php');
+require_once 'framework/main.php';

--- a/install.php
+++ b/install.php
@@ -9,5 +9,8 @@
  ************************************************************************************
  ************************************************************************************/
 
-if (!file_exists('framework') || !file_exists('framework/_config.php')) include "install-frameworkmissing.html";
-else include('./framework/dev/install/install.php');
+if (!file_exists('framework') || !file_exists('framework/_config.php')) {
+    include 'install-frameworkmissing.html';
+} else {
+    include './framework/dev/install/install.php';
+}

--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -6,7 +6,7 @@ $project = 'mysite';
 global $database;
 $database = '';
 
-require_once('conf/ConfigureFromEnv.php');
+require_once 'conf/ConfigureFromEnv.php';
 
 // Set the site locale
 i18n::set_locale('en_US');

--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -1,37 +1,10 @@
 <?php
-class Page extends SiteTree {
 
-	private static $db = array(
-	);
+class Page extends SiteTree
+{
+    private static $db = array(
+    );
 
-	private static $has_one = array(
-	);
-
-}
-class Page_Controller extends ContentController {
-
-	/**
-	 * An array of actions that can be accessed via a request. Each array element should be an action name, and the
-	 * permissions or conditions required to allow the user to access it.
-	 *
-	 * <code>
-	 * array (
-	 *     'action', // anyone can access this action
-	 *     'action' => true, // same as above
-	 *     'action' => 'ADMIN', // you must have ADMIN permissions to access this action
-	 *     'action' => '->checkAction' // you can only access this action if $this->checkAction() returns true
-	 * );
-	 * </code>
-	 *
-	 * @var array
-	 */
-	private static $allowed_actions = array (
-	);
-
-	public function init() {
-		parent::init();
-		// You can include any CSS or JS required by your project here.
-		// See: http://doc.silverstripe.org/framework/en/reference/requirements
-	}
-
+    private static $has_one = array(
+    );
 }

--- a/mysite/code/Page_Controller.php
+++ b/mysite/code/Page_Controller.php
@@ -1,0 +1,29 @@
+<?php
+
+class Page_Controller extends ContentController
+{
+    /**
+     * An array of actions that can be accessed via a request. Each array element should be an action name, and the
+     * permissions or conditions required to allow the user to access it.
+     *
+     * <code>
+     * array (
+     *     'action', // anyone can access this action
+     *     'action' => true, // same as above
+     *     'action' => 'ADMIN', // you must have ADMIN permissions to access this action
+     *     'action' => '->checkAction' // you can only access this action if $this->checkAction() returns true
+     * );
+     * </code>
+     *
+     * @var array
+     */
+    private static $allowed_actions = array(
+    );
+
+    public function init()
+    {
+        parent::init();
+        // You can include any CSS or JS required by your project here.
+        // See: http://doc.silverstripe.org/framework/en/reference/requirements
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,25 +1,24 @@
 <?xml version="1.0"?>
 <ruleset name="SS3">
-	<description>Coding standard for SilverStripe 3.x</description>
+    <description>Coding standard for SilverStripe 3.x</description>
 
-	<!-- Don't sniff third party libraries -->
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/thirdparty/*</exclude-pattern>
-	<exclude-pattern type="relative">^index.php</exclude-pattern>
+    <!-- Don't sniff third party libraries -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/thirdparty/*</exclude-pattern>
 
-	<!-- Show progress and output sniff names on violation, and add colours -->
-	<arg value="sp"/>
-	<arg name="colors"/>
+    <!-- Show progress and output sniff names on violation, and add colours -->
+    <arg value="sp"/>
+    <arg name="colors"/>
 
-	<!-- Use PSR-2 as a base standard -->
-	<rule ref="PSR2">
-		<!-- Allow classes to not declare a namespace -->
-		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+    <!-- Use PSR-2 as a base standard -->
+    <rule ref="PSR2">
+        <!-- Allow classes to not declare a namespace -->
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
 
-		<!-- Allow underscores in class names -->
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <!-- Allow underscores in class names -->
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
 
-		<!-- Allow non camel cased method names -->
-		<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
-	</rule>
+        <!-- Allow non camel cased method names -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="SS3">
+	<description>Coding standard for SilverStripe 3.x</description>
+
+	<!-- Don't sniff third party libraries -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/thirdparty/*</exclude-pattern>
+	<exclude-pattern type="relative">^index.php</exclude-pattern>
+
+	<!-- Show progress and output sniff names on violation, and add colours -->
+	<arg value="sp"/>
+	<arg name="colors"/>
+
+	<!-- Use PSR-2 as a base standard -->
+	<rule ref="PSR2">
+		<!-- Allow classes to not declare a namespace -->
+		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+
+		<!-- Allow underscores in class names -->
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+
+		<!-- Allow non camel cased method names -->
+		<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+	</rule>
+</ruleset>


### PR DESCRIPTION
**Note:** I've raised this PR against 3.4 because I think we should add this for all currently supported versions of SS 3.x.

---

This ruleset is based on PSR-2, but excludes the following rules:

* Classes must have a namespace
* Classes must be in a file of their own
* Spaces for indentation (prefer tabs)
* Method naming must be camelCase and class names must be StudlyCase (underscores break both  of these)

It will exclude the vendor and thirdparty directories it finds if running over a project, as well as the index.php file (we may want to exclude framework/main.php too?).

Issue: https://github.com/silverstripe/silverstripe-framework/issues/6643

---

Couple of things for discussion:

* While linting supported modules to adhere to these standards, should we just bite the bullet and convert to spaces now?
* I've currently excluded the "one class per file" rule completely after having made it a warning instead of an error, then changing my mind - should this remain as a rule, and should we move the classes to their own files now? I'm conscious that this has been done in 4.x already, so if we follow then it should be the same as what 4.x has done already I guess.