### PR TITLE
Add in the module folders which come from the default install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,16 @@
 
 # ignore composer vendor folder
 /vendor/
+
+# ignore default modules from composer
+/asset-admin/
+/campaign-admin/
+/cms/
+/framework/
+/graphql/
+/reports/
+/silverstripe-admin/
+/silverstripe-assets/
+/siteconfig/
+/themes/simple/
+/versioned/


### PR DESCRIPTION
composer will maintain these folders for us, ignore just like the vendor folder.

I debated a bit on the themes/simple folder, but if people are going to modify it then they will get warnings / over-written when new updates happen...~