### PR TITLE
FIX: Include .env.example and .editorconfig in git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
 .cow.json export-ignore
-.editorconfig export-ignore
-.env.example export-ignore
 .gitattributes export-ignore
 .travis.yml export-ignore
 behat.yml export-ignore


### PR DESCRIPTION
The “export” downloads of the installer should include these two files
as they are of use to regular developers.

 * .editorconfig encourages the use of our standard code format
 * .env.example is a helper for new developers