### PR TITLE
Loosen PHPUnit constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"silverstripe-themes/simple": "3.1.*"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7@stable"
+		"phpunit/phpunit": "^3 || ^4 || ^5"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
PHPUnit 3, 4, 5 have a compatible API and our test suite will run on all of those versions.

We should allow people to benefit from the bug fixes and enhancements available to them if they are running newer versions of PHP with our framework

---

Related PRs:

- [x] https://github.com/silverstripe/silverstripe-reports/pull/93
- [x] https://github.com/silverstripe/silverstripe-cms/pull/2030
- [x] https://github.com/silverstripe/silverstripe-framework/pull/7613
- [x] https://github.com/silverstripe/silverstripe-siteconfig/pull/82
- [x] https://github.com/silverstripe/silverstripe-travis-support/pull/49