### PR TITLE
Ignore (almost) everything in the assets folder

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,4 +1,4 @@
-# Ignore sensible defaults
-/*/
-/error-*.html
-/_combinedfiles/
+/**/*
+!.gitignore
+!.htaccess
+!web.config


### PR DESCRIPTION
Duplicated from #212 as I'm told pull requests to 3.5 will get merged into 4.x eventually.

Uploading files directly through the Files LeftAndMain drops them directly into the assets folder by default. This will help prevent those files accidentally ending up in git.