### PR TITLE
Remove show progress from phpcs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,7 @@
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*/thirdparty/*</exclude-pattern>
 
-    <!-- Show progress and output sniff names on violation, and add colours -->
-    <arg value="sp"/>
+    <!-- Add colours -->
     <arg name="colors"/>
 
     <!-- Use PSR-2 as a base standard -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,8 @@
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <exclude-pattern>*/thirdparty/*</exclude-pattern>
 
-    <!-- Add colours -->
+    <!-- Output sniff names on violation and add colours -->
+    <arg value="s"/>
     <arg name="colors"/>
 
     <!-- Use PSR-2 as a base standard -->


### PR DESCRIPTION
The 'sp' or 'show-progress' argument causes the phpcs plugin for vscode to not work and doesn't give any explanation why, it only spits out errors "phpcs: Unexpected token  in JSON at position 0" which would be super confusing for the average user

