### PR TITLE
Update .gitignore

### DIFF
--- a/public/assets/.gitignore
+++ b/public/assets/.gitignore
@@ -1,4 +1,4 @@
-# Ignore sensible defaults
-/*/
-/error-*.html
-/_combinedfiles/
+/**/*
+!.gitignore
+!.htaccess
+!web.config


### PR DESCRIPTION
Update to match #213.
Now that `assets/` has moved into `public/` not sure if the last PR is able to propagate to 4.