### PR TITLE
Update phpunit deps to match framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"silverstripe-themes/simple": "3.1.*"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7@stable"
+		"phpunit/phpunit": "^3 || ^4 || ^5"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
SS 3.x supports PHP 7 so we need to allow a range of PHPUnit versions