### PR TITLE
FIX Remove incorrect classmap for Page and PageController

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,6 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7"
     },
-    "autoload": {
-        "classmap": [
-            "app/src/Page.php",
-            "app/src/PageController.php"
-        ]
-    },
     "extra": {
         "project-files": [
             "app/_config/*",


### PR DESCRIPTION
These files to not always exist in this path, so this autoload definition is misleading

For example, if a project requires the installer recipe then it gets installed into vendor/silverstripe/installer, so this classmap is very wrong - the files belong to the silverstripe/recipe-cms recipe so should be loaded there if anywhere