### PR TITLE
MINOR Make installer default to using `_resources`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /.env
 /vendor/
 /themes/simple/
-/resources/
-/public/resources/
+/_resources/
+/public/_resources/

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         ],
         "branch-alias": {
             "4.x-dev": "4.4.x-dev"
-        }
+        },
+        "resources-dir": "_resources"
     },
     "config": {
         "process-timeout": 600


### PR DESCRIPTION
Make `_resources` the default location for vendor-expose in 4.4

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/7932