### PR TITLE
Add Roave Security advisories to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "silverstripe-themes/simple": "~3.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "roave/security-advisories": "dev-master"
     },
     "extra": {
         "project-files": [


### PR DESCRIPTION
Add Security Advisories as dev requirement to
- Prevent installation of known breached libraries
- Give devs the option to remove it if they might want to

Related: silverstripe/silverstripe-framework#8548