### PR TITLE
Split framework tests from assets and versioned to prevent time limits being exceeded

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,10 +15,6 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
-indent_size = 2
-indent_style = space
-
 [*.{yml,json}]
 # The indent size used in the `package.json` file cannot be changed
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,20 @@ matrix:
         - PHPUNIT_TEST=core
         - DB=MYSQL
         - PDO=1
-    - php: 7.1.2
+    - php: 7.1
+      env:
+        - PHPUNIT_TEST=framework
+        - DB=MYSQL
+    - php: 7.3
       env:
         - PHPUNIT_TEST=core
         - DB=PGSQL
     # admin php tests
-    - php: 5.6
+    - php: 7.0
       env:
         - PHPUNIT_TEST=admin
         - DB=PGSQL
-    - php: 7.1.2
+    - php: 7.2
       env:
         - PHPUNIT_TEST=admin
         - DB=MYSQL

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,11 +4,12 @@
 	Requires PHPUnit 5+
 
 	Usage:
-	 - "phpunit": Runs all tests in all folders
-	 - "phpunit framework/tests/": Run all tests of the framework module
-	 - "phpunit framework/tests/filesystem": Run all filesystem tests within the framework module
-	 - "phpunit framework/tests/filesystem/FolderTest.php": Run a single test
-	 - "phpunit <dash><dash>coverage-html assets/": Generate coverage report (replace <dash> with "-", requires xdebug)
+	 - "vendor/bin/phpunit": Runs all tests in all folders
+	 - "vendor/bin/phpunit vendor/silverstripe/framework/tests/": Run all tests of the framework module
+	 - "vendor/bin/phpunit vendor/silverstripe/framework/tests/filesystem": Run all filesystem tests within framework
+	 - "vendor/bin/phpunit vendor/silverstripe/framework/tests/filesystem/FolderTest.php": Run a single test
+	 - "vendor/bin/phpunit <dash><dash>coverage-html assets/": Generate coverage report (replace
+	                                                           <dash> with "-", requires xdebug or phpdbg)
 
 	More information:
 	- http://www.phpunit.de/manual/current/en/textui.html
@@ -17,34 +18,31 @@
 	It is safe to remove this file for normal website operation.
 -->
 <phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+    <testsuite name="Default">
+        <directory>mysite/tests</directory>
+        <directory>vendor/silverstripe/cms/tests/php</directory>
+        <directory>vendor/silverstripe/framework/tests/php</directory>
+    </testsuite>
 
-	<testsuite name="Default">
-		<directory>mysite/tests</directory>
-		<directory>vendor/silverstripe/cms/tests/php</directory>
-		<directory>vendor/silverstripe/framework/tests/php</directory>
-	</testsuite>
+    <!-- framework only -->
+    <testsuite name="framework">
+        <directory>vendor/silverstripe/framework/tests/php/</directory>
+    </testsuite>
 
-    <!-- core components -->
+    <!-- other core components -->
     <testsuite name="core">
-		<directory>vendor/silverstripe/framework/tests/php/</directory>
-		<directory>vendor/silverstripe/assets/tests/php/</directory>
+        <directory>vendor/silverstripe/assets/tests/php/</directory>
         <directory>vendor/silverstripe/versioned/tests/php/</directory>
     </testsuite>
 
     <!-- admin components -->
     <testsuite name="admin">
-        <directory>vendor/silverstripe/cms/tests/</directory>
         <directory>vendor/silverstripe/admin/tests/php/</directory>
-        <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
         <directory>vendor/silverstripe/asset-admin/tests/php/</directory>
+        <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
+        <directory>vendor/silverstripe/cms/tests/</directory>
         <directory>vendor/silverstripe/graphql/tests/</directory>
-        <directory>vendor/silverstripe/siteconfig/tests/php/</directory>
         <directory>vendor/silverstripe/reports/tests/</directory>
+        <directory>vendor/silverstripe/siteconfig/tests/php/</directory>
     </testsuite>
-
-	<groups>
-		<exclude>
-			<group>sanitychecks</group>
-		</exclude>
-	</groups>
 </phpunit>


### PR DESCRIPTION
Also removed an unneeded editorconfig block which is duplicated and adds PHP 7.2 and 7.3 into the builds