### PR TITLE
Remove cow archive metadata

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -13,21 +13,5 @@
   ],
   "exclude": [
     "silverstripe/recipe-plugin"
-  ],
-  "archives": [
-    {
-      "recipe": "silverstripe/recipe-core",
-      "files": [
-        "SilverStripe-framework-v{version}.zip",
-        "SilverStripe-framework-v{version}.tar.gz"
-      ]
-    },
-    {
-      "recipe": "silverstripe/installer",
-      "files": [
-        "SilverStripe-cms-v{version}.zip",
-        "SilverStripe-cms-v{version}.tar.gz"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/9232.
This should be merged up to 4.4 and 4.