### PR TITLE
Add redirects to `public/` for iis

### DIFF
--- a/web.config
+++ b/web.config
@@ -5,6 +5,9 @@
             <rules>
                 <rule name="SilverStripe Global URLs">
                     <match url="^(.*)$" />
+                    <conditions>
+                        <add input="{R:1}" matchType="Pattern" pattern="public(/|$)" negate="true" />
+                    </conditions>
                     <action type="Rewrite" url="public/{R:1}" appendQueryString="true" />
                 </rule>
                 <rule name="SilverStripe Preprocessed URLs" stopProcessing="true">

--- a/web.config
+++ b/web.config
@@ -1,0 +1,20 @@
+<!-- Routing configuration for Microsoft IIS web server -->
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <rule name="SilverStripe Global URLs">
+                    <match url="^(.*)$" />
+                    <action type="Rewrite" url="public/{R:1}" appendQueryString="true" />
+                </rule>
+                <rule name="SilverStripe Preprocessed URLs" stopProcessing="true">
+                    <match url="^(.*)$" />
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="public/index.php" appendQueryString="true" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
This commit fixes #262.
This commit adds a `web.config`-file to the project's root which redirects all urls to `public/` in order to make SilverStripe & IIS act the same like SilverStripe & Apache.