### PR TITLE
Set environment type in example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ SS_DATABASE_SERVER="localhost"
 SS_DATABASE_USERNAME="<user>"
 SS_DATABASE_PASSWORD="<password>"
 SS_DATABASE_NAME="<database>"
+
+# WARNING: in a live environent, change this to "live" instead of dev
+SS_ENVIRONMENT_TYPE="dev"


### PR DESCRIPTION
When running a dev/build for the first time, environment should be set to 'dev' or it won't run. 
Setting this in the example gives guidance to someone building a site for the first time (or if it's been ages!)