### PR TITLE
DOC Adjust changelog template for RC releases

### DIFF
--- a/.cow/changelog.md.twig
+++ b/.cow/changelog.md.twig
@@ -4,9 +4,19 @@
 
 - 
 
+{% if version.stability == 'rc' %}
+
+## Release Candidate
+
+This version of Silverstripe CMS is a **release candidate** for an upcoming stable version, and should not be applied to production websites. We encourage developers to test this version in development / testing environments and report any issues they encounter via GitHub.
+
+{% elseif version.stable %}
+
 ## Upgrading {{ '{#upgrading}' }}
 
 ...
+
+{% endif %}
 
 {{ logs }}
 


### PR DESCRIPTION
Following the [addition of the full `Version` object](https://github.com/silverstripe/cow/pull/157) to the template handler in Cow, we can apply a specific message to the changelog for RCs.