### PR TITLE
BUG Don't include the .cow folders in releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 .cow.json export-ignore
+.cow export-ignore
 .gitattributes export-ignore
 .travis.yml export-ignore
 behat.yml export-ignore


### PR DESCRIPTION
The .cow folder is only useful when doing a release with cow. People don't need it when starting a new project.

# Parent issue
* Resolves #287