### PR TITLE
MNT Use admin behat suite instead of framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       env:
         - DB=MYSQL
         - BEHAT_TEST=1
-        - BEHAT_SUITE="framework"
+        - BEHAT_SUITE="admin"
     - php: 7.2
       env:
         - DB=MYSQL


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-installer/issues/300

There are no framework behat tests.  The framework behat setup is a non-standard setup that just calls the admin suite.  I'm not sure what the historic background for why it's like this is, though it just seems like we should just call the admin behat suite directly like we do for everything else.

There's some other unrelated broken tests on the travis build