### PR TITLE
ENH Explicitly allow SilverStripe composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "resources-dir": "_resources"
     },
     "config": {
-        "process-timeout": 600
+        "process-timeout": 600,
+        "allow-plugins": {
+            "silverstripe/recipe-plugin": true,
+            "silverstripe/vendor-plugin": true
+        }
     },
     "prefer-stable": true,
     "minimum-stability": "dev"


### PR DESCRIPTION
As of Composer 2.2.0, there is a new configuration property to whitelist plugins which are allowed to run. According to https://getcomposer.org/doc/06-config.md#allow-plugins this will default to disallow all plugins from July 2022.