### PR TITLE
MNT Add composer/installers to allow-plugins by default.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "config": {
         "process-timeout": 600,
         "allow-plugins": {
+            "composer/installers": true,
             "silverstripe/recipe-plugin": true,
             "silverstripe/vendor-plugin": true
         }


### PR DESCRIPTION
This plugin is always required for silverstripe installs, so we should allow it by default.

## Parent Issue
- silverstripeltd/product-issues#528