### PR TITLE
MNT Only use mysql in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - PHPUNIT_SUITE="framework"
     - php: 7.4
       env:
-        - DB=PGSQL
+        - DB=MYSQL
         - PHPUNIT_TEST=1
         - PHPUNIT_SUITE="core"
     - php: 8.0
@@ -51,7 +51,7 @@ matrix:
         - COMPOSER_INSTALL_ARG="--prefer-lowest"
     - php: 7.4
       env:
-        - DB=PGSQL
+        - DB=MYSQL
         - PHPUNIT_TEST=1
         - PHPUNIT_SUITE="admin"
     - php: 8.0


### PR DESCRIPTION
PGSQL tests are failing for no apparent reason, cannot replicate locally

https://app.travis-ci.com/github/silverstripe/silverstripe-installer/jobs/568487613#L1390

We have PGSQL in the shared config, so there's still plenty of times that we're testing the postgres still functions
