### PR TITLE
ENH Add `.graphql-generated` directory by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "extra": {
         "project-files": [
             "app/_config/*",
-            ".env.example"
+            ".env.example",
+            ".graphql-generated/*"
         ],
         "public-files": [
             "assets/*",


### PR DESCRIPTION
This directory will be required for all new projects (unless explicitly opting out of graphql v4) - having this directory by default makes it easier to set more sane permissions (i.e. not requiring the entire project root to be writable).

In silverstripe/silverstripe-framework#10339 the docs are being updated to say this is best practice - so this PR gives best practice out-of-the-box.