### PR TITLE
ENH Add and ignore public/_graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /themes/simple/
 /_resources/
 /public/_resources/
-/.graphql-generated
+/.graphql-generated/
+/public/_graphql/


### PR DESCRIPTION
silverstripe/graphql v4 needs write access to this directory, so it may be easier for some developers to have the directory there as soon as they `composer create_project silverstripe/installer`.

Like `.graphql-generated`, best practice is to not commit this directory to VCS, and instead let it be filled at deploy time.

Related to #323

## Parent Issue
- https://github.com/silverstripeltd/product-issues/issues/544