### PR TITLE
MNT Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,6 @@
             "assets/*",
             "favicon.ico"
         ],
-        "branch-alias": {
-            "dev-master": "5.x-dev"
-        },
         "resources-dir": "_resources"
     },
     "config": {


### PR DESCRIPTION
We're gonna delete this branch soon anyway but in the meantime this branch alias is showing up with `composer show` and is causing problems with a really specific use-case with my setup.