### PR TITLE
DEP Require dev branches for composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "The SilverStripe Framework Installer",
     "require": {
         "php": "^8.1",
-        "silverstripe/recipe-plugin": "^2",
+        "silverstripe/recipe-plugin": "2.x-dev",
+        "silverstripe/vendor-plugin": "2.x-dev",
         "silverstripe/recipe-cms": "5.x-dev",
         "silverstripe-themes/simple": "~3.2.0",
         "silverstripe/login-forms": "5.x-dev"


### PR DESCRIPTION
This will fix a problem where our CI is checking out the alpha versions instead of the current dev branch: https://github.com/silverstripe/silverstripe-cms/actions/runs/3691417604/jobs/6249397761#step:9:522

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/642