### PR TITLE
MNT Remove unnecessary .htaccess file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,0 @@
-RewriteEngine On
-RewriteRule ^(.*)$ public/$1

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
             "app/_config/*",
             ".env.example",
             ".graphql-generated/*"
+
         ],
         "public-files": [
             "assets/*",


### PR DESCRIPTION
Now that the public directory is mandatory, we must make sure we're pulling in `.htaccess` whenever recipe-core is included as a dependency to ensure apache traffic flows through that folder.

Any project using `composer create-project silverstripe/recipe-core` will have `.htaccess` in the project root by default, but using any other recipe (e.g. `composer create-project silverstripe/recipe-blog` or some custom bespoke recipe), or when adding `silverstripe/installer` as a dependency in CI, it needs to be included by `silverstripe/recipe-plugin`.

This is handled by https://github.com/silverstripe/recipe-core/pull/83, which makes the `.htaccess` file in this recipe redundant.

## CI

The CI for this PR is failing because there's no `.htaccess` file directing to the public dir - but I have run a CI which includes https://github.com/silverstripe/recipe-core/pull/83 here: https://github.com/creative-commoners/silverstripe-installer/actions/runs/3700053389 which shows how this PR interacts with that one.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/642