### PR TITLE
DEP Update constraint for vendor-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/recipe-plugin": "2.0.x-dev",
-        "silverstripe/vendor-plugin": "2.0.x-dev",
+        "silverstripe/vendor-plugin": "3.0.x-dev",
         "silverstripe/recipe-cms": "6.0.x-dev",
         "silverstripe-themes/simple": "3.3.x-dev",
         "silverstripe/login-forms": "6.0.x-dev"


### PR DESCRIPTION
It's not strictly necessary since this is a dependency of silverstripe/framework, but IMO it's good practice for projects to have a reference to vendor-plugin, since the `composer vendor-expose` command is specifically intended for use by projects.

## Issue
- https://github.com/silverstripe/.github/issues/311