### PR TITLE
DEP Add new TinyMCE module as an explicit dependency.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,6 @@ jobs:
         - endtoend: true
           endtoend_suite: cms
           endtoend_config: vendor/silverstripe/cms/behat.yml
+        - endtoend: true
+          endtoend_suite: htmleditor-tinymce
+          endtoend_config: vendor/silverstripe/htmleditor-tinymce/behat.yml

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "silverstripe/vendor-plugin": "3.0.x-dev",
         "silverstripe/recipe-cms": "6.0.x-dev",
         "silverstripe/startup-theme": "1.0.x-dev",
-        "silverstripe/login-forms": "6.0.x-dev"
+        "silverstripe/login-forms": "6.0.x-dev",
+        "silverstripe/htmleditor-tinymce": "1.0.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,6 +38,7 @@
         <!-- other core components -->
         <testsuite name="core">
             <directory>vendor/silverstripe/assets/tests/php/</directory>
+            <directory>vendor/silverstripe/htmleditor-tinymce/tests/php/</directory>
             <directory>vendor/silverstripe/versioned/tests/php/</directory>
         </testsuite>
 


### PR DESCRIPTION
This will allow us to swap in a different default HTML editor in the future, while existing projects will be able to keep this one in their own dependencies.

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/2