### PR TITLE
DEP Use correct dep for recipe-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.3",
-        "silverstripe/recipe-plugin": "2.0.x-dev",
+        "silverstripe/recipe-plugin": "2.1.x-dev",
         "silverstripe/vendor-plugin": "3.0.x-dev",
         "silverstripe/recipe-cms": "6.0.x-dev",
         "silverstripe/startup-theme": "1.0.x-dev",


### PR DESCRIPTION
This is the version included in 5.4, so it's the version we need to use here in lieu of a new major.

This constraint is causing cow to dislike me.

Needs https://github.com/silverstripe/recipe-core/pull/108 and https://github.com/silverstripe/recipe-cms/pull/98 merged before it can go green

## Issue

- https://github.com/silverstripe/.github/issues/382