### PR TITLE
FIX Allow files with dots in the name

### DIFF
--- a/public/assets/.htaccess
+++ b/public/assets/.htaccess
@@ -24,8 +24,8 @@ AddHandler default-handler php phtml php3 php4 php5 inc
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule error[^\\/]*\.html$ - [L]
 
-    # Block invalid file extensions
-    RewriteCond %{REQUEST_URI} !^[^.]*\.(?i:css|js|ace|arc|arj|asf|au|avi|bmp|bz2|cab|cda|csv|dmg|doc|docx|dotx|flv|gif|gpx|gz|hqx|ico|jpeg|jpg|kml|m4a|m4v|mid|midi|mkv|mov|mp3|mp4|mpa|mpeg|mpg|ogg|ogv|pages|pcx|pdf|png|pps|ppt|pptx|potx|ra|ram|rm|rtf|sit|sitx|tar|tgz|tif|tiff|txt|wav|webm|wma|wmv|xls|xlsx|xltx|zip|zipx)$
+    # Allow specific file extensions
+    RewriteCond %{REQUEST_URI} !^[^.]*[^\/]*\.(?i:css|js|ace|arc|arj|asf|au|avi|bmp|brf|bz2|cab|cda|csv|dmg|doc|docx|dotx|flv|gif|gz|hqx|ico|jpeg|jpg|kml|m4a|m4v|mid|midi|mkv|mov|mp3|mp4|mpa|mpeg|mpg|ogg|ogv|pages|pcx|pdf|png|pps|ppt|pptx|potx|ra|ram|rm|rtf|sit|sitx|tar|tgz|tif|tiff|txt|wav|webm|webp|wma|wmv|xls|xlsx|xltx|zip|zipx)$
     RewriteRule .* - [F]
 
     # Non-existent files passed to requesthandler


### PR DESCRIPTION
Also updates the allowed file extensions to match the file generated with a default installation.

A fresh installation with CMS 5 didn't exhibit the bug, so I'm not targetting 5.4. I think in 5 the file was being re-rendered a bit more aggressively than it is here.

It's unusual for us to do patches on recipes without also patching dependencies and releasing a changelog - but it's not unprecedented (see [4.12.1](https://github.com/silverstripe/silverstripe-installer/releases/tag/4.12.1) which doesn't have a corresponding changelog). Granted that was to fix dependencies so the thing could even be installed which is a different scenario.
That said, I'm not going to complain if asked to retarget `6`, since it is _unusual_ to tag patches on a recipe.

## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/704